### PR TITLE
Replace deprecated dispatch queue priority constant

### DIFF
--- a/Source/BasicHacks.mm
+++ b/Source/BasicHacks.mm
@@ -50,7 +50,7 @@ void BasicHacks::HacksThread() {
 }
 
 - (void)start {
-    dispatch_queue_t queue = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0);
+    dispatch_queue_t queue = dispatch_get_global_queue(QOS_CLASS_DEFAULT, 0);
 
     _timer = dispatch_source_create(DISPATCH_SOURCE_TYPE_TIMER, 0, 0, queue);
 


### PR DESCRIPTION
## Summary
- use QOS_CLASS_DEFAULT with dispatch_get_global_queue for iOS 18 compatibility

## Testing
- `make` *(fails: No rule to make target '/makefiles/aggregate.mk')*

------
https://chatgpt.com/codex/tasks/task_e_689aeb9f1ebc83279e03317ee8f50961