### PR TITLE
Replace deprecated keyWindow usage with modern window lookup

### DIFF
--- a/MenuLoad/MenuLoad.mm
+++ b/MenuLoad/MenuLoad.mm
@@ -93,7 +93,11 @@ bool isOpened = false;
         hideRecordView = nil;
     }
 
-    [[UIApplication sharedApplication].keyWindow addSubview:hideRecordView];
+    UIWindow *window = UIApplication.sharedApplication.windows.firstObject;
+    if (!window) {
+        return;
+    }
+    [window addSubview:hideRecordView];
 
     if (!_vna) {
         ImGuiDrawView *vc = [[ImGuiDrawView alloc] init];


### PR DESCRIPTION
## Summary
- Replace deprecated keyWindow usage in `MenuLoad` with modern window lookup.
- Early return when no application window is available.

## Testing
- `make` *(fails: Makefile:27: /makefiles/aggregate.mk: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689aedc5deb88327a8723435ccbfede2