### PR TITLE
Refactor iOS ImGui template architecture

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,28 +1,44 @@
 # AI Agent Instructions
 
 ## Purpose
-This repository is an iOS Theos-based tweak template for a jailed (non-jailbroken) mod menu with an ImGui UI layer. Use the notes below when making changes or answering questions.
+This repository is an iOS Theos-based tweak template for a jailed (non-jailbroken) mod menu with a Dear ImGui + Metal UI layer. Keep new work modular so the template remains useful as a starting point for future projects.
 
 ## Theos build system notes
-- **Build tooling**: The project is built as a Theos tweak using the `Makefile` in the repo root. It defines `TWEAK_NAME = KTemp` and builds arm64 for `iphone:clang:latest:latest`.
-- **Source inclusion**: The tweak pulls Objective-C/Objective-C++ sources from `MenuLoad/`, `Source/`, and ImGui sources under `ImGui/` via wildcard globs in the Makefile.
-- **Typical commands** (from Theos conventions): `make`, `make package`, and `make install` are the usual entry points. Ensure the Theos toolchain is installed as described in the README.
+- **Build tooling**: The project is built as a Theos tweak using the root `Makefile` with `TWEAK_NAME = KTemp` and arm64 targeting.
+- **Source inclusion**: Objective-C/Objective-C++ sources under `MenuLoad/` and `Source/` are included by the existing wildcard rules. ImGui sources live under `ImGui/`.
+- **Typical commands**: `make`, `make package`, and `make install`.
 
-## Entry points / runtime flow
-- **Initial load**: `MenuLoad` uses `+load` to initialize the UI after a delay (via a timer) and inserts the ImGui view and menu button into the app window hierarchy.
-- **ImGui bootstrap**: `ImGuiDrawView` initializes the Metal device, ImGui context, and font in `-initWithNibName:bundle:`. It calls `BasicCheats.Initialize()` to start the gameplay loop/hack thread once the view is created.
-- **Render loop**: `ImGuiDrawView` implements `MTKViewDelegate` and draws ImGui every frame in `-drawInMTKView:`. Menu visibility is gated by `MenDeal` and toggled from the floating button.
-- **Hack loop**: `BasicHacks::Initialize()` starts a GCD timer that repeatedly calls `BasicHacks::HacksThread()` at ~30 FPS to apply memory edits (e.g., FOV changes).
+## Runtime flow
+1. `TweakManager` is the single tweak bootstrap point. Its `+load` preserves the template's short delayed startup and calls `start` once.
+2. `TweakManager` initializes non-UI feature logic (`BasicCheats.Initialize()`) and starts `MenuLoad`.
+3. `MenuLoad` owns UIKit composition: active-window discovery, the secure capture host used by streamer mode, the floating launcher, and the touch-routing view.
+4. `ImGuiDrawView` owns the `MTKView`, Metal device/queue, and one concise per-frame render loop.
+5. `ImGuiController` owns the Dear ImGui lifecycle: context/font/backend initialization, `NewFrame`, render submission, touch-to-ImGui input translation, and shutdown.
+6. `UserMenu` contains only ImGui drawing. `Draw(bool menuVisible)` draws the interactive menu when visible and the non-interactive overlay every frame.
+7. `AppState` contains shared runtime values. `KTempVars` remains as a compatibility alias so existing feature code can migrate incrementally.
 
-## Codebase system design
-- **UI layer**: `MenuLoad/` owns UI composition (floating button + ImGui view) and touch routing for the menu interaction layer.
-- **Menu content**: `UserMenu` defines ImGui windows and menu state binding to `KTempVars` values (e.g., FOV, streamer mode).
-- **Gameplay logic**: `Source/BasicHacks.mm` contains the example “hack” loop and offsets for an Unreal Engine-based title. It uses `KomaruPatch` for memory reads/writes.
-- **Memory utilities**: `utils/KPatch.hpp` implements guarded read/write helpers using `mach_vm_region` and `vm_read_overwrite` for safety on jailed devices.
-- **ImGui integration**: Core ImGui sources live in `ImGui/`, with the Metal backend invoked from the ImGui draw view.
+## Design boundaries
+- **TweakManager**: startup/coordinator only. Do not put rendering, hooks, or feature implementation here.
+- **MenuLoad**: UIKit overlay/controller only. Keep host-app window handling, launcher behavior, touch routing, and streamer-mode presentation here.
+- **ImGuiDrawView**: Metal frame orchestration only. A frame should read as: acquire pass -> begin ImGui frame -> draw menu -> render -> present.
+- **ImGuiController**: all Dear ImGui lifecycle/backend/input details.
+- **UserMenu**: ImGui controls and draw-list code only. Avoid memory writes or gameplay logic inside widgets.
+- **AppState**: lightweight shared state with no UIKit or Metal dependencies.
+- **Source/**: feature/game logic. UI should bind to state rather than performing memory edits directly.
+- **utils/**: low-level reusable helpers such as `KPatch.hpp`.
 
-## Notable TODOs / next features (expected follow-up work)
-- **Offset maintenance**: Update the Unreal Engine offsets in `Source/BasicHacks.mm` per target game version and platform updates. This requires per-title reverse engineering and validation in runtime tests.
-- **Feature wiring**: Add additional menu toggles and tie them to new memory edits in `BasicHacks` or new modules. This requires new `KTempVars` fields and corresponding ImGui controls in `UserMenu`.
-- **UI polish**: Improve the floating menu button UX (snap-to-edge, persistence, or scaling). This requires UI state handling in `MenuLoad`.
-- **Rendering overlay**: Fill out the rendering-only overlay in `UserMenu::RenderingMenu()` for ESP or debug visuals, which requires new ImGui draw calls and access to game state.
+## Dependency guidance
+Prefer explicit includes. `Includes.h` exists only as a compatibility header for older feature modules and should stay small. Do not turn it back into an umbrella header importing Metal, ImGui internals, menu controllers, and unrelated STL headers.
+
+Features should depend on state, not ImGui. For example, an ImGui checkbox should update an `AppState` field, while a feature module reads that field and performs its own work.
+
+## Input and overlays
+- `MenuInteraction` forwards touches only when they fall inside the current ImGui menu bounds, allowing the host app to receive touches elsewhere.
+- The floating launcher uses one transparent input surface plus one visual mirror inside the capture host. Keep this separation because the visual layer may be hosted inside the secure text-field hierarchy for streamer mode.
+- Rendering-only overlays should use ImGui draw lists directly; do not create invisible full-screen ImGui windows unless input/layout behavior genuinely requires one.
+
+## Extension points
+- Add new menu controls in `UserMenu` and store their state in `AppState` or a dedicated feature state object.
+- Add feature implementations under `Source/` rather than expanding `UserMenu`.
+- If feature count grows, split `AppState` into smaller domain-specific state objects instead of adding unrelated globals.
+- Prefer dedicated hook/feature modules over placing hooks in the renderer or menu controller.

--- a/MenuLoad/AppState.h
+++ b/MenuLoad/AppState.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include "../ImGui/imgui.h"
+
+// Shared runtime state used by the sample menu and feature modules.
+// Keep this file free of UIKit/Metal dependencies so non-UI code can consume it.
+struct AppState {
+    static AppState& Shared() {
+        static AppState instance;
+        return instance;
+    }
+
+    ImVec2 MenuSize = ImVec2(0.0f, 0.0f);
+    ImVec2 MenuOrigin = ImVec2(0.0f, 0.0f);
+
+    bool StreamerMode = false;
+    bool MoveMenu = false;
+
+    bool ShowEspOverlay = true;
+    bool ShowEspSnaplines = true;
+    bool ShowEspMarkers = true;
+    bool ShowEspBoxes = true;
+    bool ShowEspLabels = true;
+    bool ShowEspHealthBars = true;
+
+    float CameraFOV = 90.0f;
+
+private:
+    AppState() = default;
+};
+
+// Compatibility alias for existing feature code.
+static AppState& KTempVars = AppState::Shared();

--- a/MenuLoad/ImGuiController.h
+++ b/MenuLoad/ImGuiController.h
@@ -1,0 +1,25 @@
+#import <UIKit/UIKit.h>
+#import <Metal/Metal.h>
+#import <MetalKit/MetalKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+// Owns the Dear ImGui lifecycle for the Metal renderer.
+// ImGuiDrawView only drives this controller once per MTKView frame.
+@interface ImGuiController : NSObject
+
+- (instancetype)initWithDevice:(id<MTLDevice>)device NS_DESIGNATED_INITIALIZER;
+- (instancetype)init NS_UNAVAILABLE;
+
+- (void)beginFrameWithView:(MTKView *)view
+      renderPassDescriptor:(MTLRenderPassDescriptor *)renderPassDescriptor;
+
+- (void)renderWithCommandBuffer:(id<MTLCommandBuffer>)commandBuffer
+                  renderEncoder:(id<MTLRenderCommandEncoder>)renderEncoder;
+
+- (void)updateInputWithTouchEvent:(UIEvent *)event inView:(UIView *)view;
+- (void)shutdown;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/MenuLoad/ImGuiController.mm
+++ b/MenuLoad/ImGuiController.mm
@@ -1,0 +1,114 @@
+#import "ImGuiController.h"
+
+#include "../ImGui/imgui.h"
+#include "../ImGui/imgui_impl_metal.h"
+#include "../Font.h"
+
+@interface ImGuiController ()
+@property (nonatomic, strong) id<MTLDevice> device;
+@property (nonatomic, assign) BOOL initialized;
+@end
+
+@implementation ImGuiController
+
+- (instancetype)initWithDevice:(id<MTLDevice>)device {
+    self = [super init];
+    if (!self) return nil;
+
+    _device = device;
+    [self initializeImGui];
+    return self;
+}
+
+- (void)initializeImGui {
+    if (self.initialized) return;
+
+    IMGUI_CHECKVERSION();
+    ImGui::CreateContext();
+
+    ImGuiIO& io = ImGui::GetIO();
+    io.IniFilename = nullptr;
+    io.Fonts->Clear();
+
+    ImFontConfig fontConfig;
+    fontConfig.FontDataOwnedByAtlas = false;
+    io.FontDefault = io.Fonts->AddFontFromMemoryCompressedBase85TTF(
+        CurvyBase85,
+        16.0f,
+        &fontConfig,
+        io.Fonts->GetGlyphRangesChineseFull()
+    );
+
+    ImGui::StyleColorsClassic();
+    ImGui_ImplMetal_Init(self.device);
+
+    self.initialized = YES;
+}
+
+- (void)beginFrameWithView:(MTKView *)view
+      renderPassDescriptor:(MTLRenderPassDescriptor *)renderPassDescriptor {
+    if (!self.initialized) return;
+
+    ImGuiIO& io = ImGui::GetIO();
+    io.DisplaySize = ImVec2(view.bounds.size.width, view.bounds.size.height);
+
+    CGFloat scale = view.window.screen.nativeScale;
+    if (scale <= 0.0f) scale = UIScreen.mainScreen.nativeScale;
+    io.DisplayFramebufferScale = ImVec2(scale, scale);
+
+    NSInteger framesPerSecond = view.preferredFramesPerSecond;
+    io.DeltaTime = 1.0f / (float)(framesPerSecond > 0 ? framesPerSecond : 60);
+
+    ImGui_ImplMetal_NewFrame(renderPassDescriptor);
+    ImGui::NewFrame();
+}
+
+- (void)renderWithCommandBuffer:(id<MTLCommandBuffer>)commandBuffer
+                  renderEncoder:(id<MTLRenderCommandEncoder>)renderEncoder {
+    if (!self.initialized) return;
+
+    ImGui::Render();
+    ImGui_ImplMetal_RenderDrawData(ImGui::GetDrawData(), commandBuffer, renderEncoder);
+}
+
+- (void)updateInputWithTouchEvent:(UIEvent *)event inView:(UIView *)view {
+    if (!self.initialized) return;
+
+    ImGuiIO& io = ImGui::GetIO();
+    NSSet<UITouch *> *touches = event.allTouches;
+
+    UITouch *activeTouch = nil;
+    UITouch *lastTouch = nil;
+
+    for (UITouch *touch in touches) {
+        lastTouch = touch;
+        if (touch.phase == UITouchPhaseBegan ||
+            touch.phase == UITouchPhaseMoved ||
+            touch.phase == UITouchPhaseStationary) {
+            activeTouch = touch;
+            break;
+        }
+    }
+
+    UITouch *positionTouch = activeTouch ?: lastTouch;
+    if (positionTouch) {
+        CGPoint location = [positionTouch locationInView:view];
+        io.MousePos = ImVec2(location.x, location.y);
+    }
+
+    io.MouseDown[0] = (activeTouch != nil);
+}
+
+- (void)shutdown {
+    if (!self.initialized) return;
+
+    ImGui_ImplMetal_Shutdown();
+    ImGui::DestroyContext();
+    self.initialized = NO;
+}
+
+- (void)dealloc {
+    [self shutdown];
+}
+
+@end

--- a/MenuLoad/ImGuiDrawView.h
+++ b/MenuLoad/ImGuiDrawView.h
@@ -1,21 +1,17 @@
-/*
-IOS Theos Template Komaru
-Jailed (NoJB) Mod Menu Template for iOS Games
-By aq9
-https://github.com/VenerableCode/iOS-Theos-ModMenuTemp-NoJB
-*/
-
-
 #import <UIKit/UIKit.h>
-NS_ASSUME_NONNULL_BEGIN
 
+NS_ASSUME_NONNULL_BEGIN
 
 @interface ImGuiDrawView : UIViewController
 
-+ (void)showChange:(BOOL)open;
++ (void)setMenuVisible:(BOOL)visible;
 + (BOOL)isMenuShowing;
-- (void)updateIOWithTouchEvent:(UIEvent *)event;
 
+// Legacy name kept so existing template code continues to compile.
++ (void)showChange:(BOOL)open;
+
+// MenuInteraction forwards UIKit touch events through this single entry point.
+- (void)updateIOWithTouchEvent:(UIEvent *)event;
 
 @end
 

--- a/MenuLoad/ImGuiDrawView.xm
+++ b/MenuLoad/ImGuiDrawView.xm
@@ -1,183 +1,114 @@
-#include "Includes.h"
+#import "ImGuiDrawView.h"
+#import "ImGuiController.h"
+
 #include "UserMenu.h"
-#include "../Font.h"
-#include "../Source/BasicHacks.h"
+
+#import <Metal/Metal.h>
+#import <MetalKit/MetalKit.h>
 
 @interface ImGuiDrawView () <MTKViewDelegate>
 
-@property (nonatomic, strong) id <MTLDevice> device;
-@property (nonatomic, strong) id <MTLCommandQueue> commandQueue;
+@property (nonatomic, strong) id<MTLDevice> device;
+@property (nonatomic, strong) id<MTLCommandQueue> commandQueue;
+@property (nonatomic, strong) ImGuiController *imguiController;
 
 @end
 
 @implementation ImGuiDrawView
 
-static bool MenDeal = true;
+static BOOL sMenuVisible = NO;
 
-- (instancetype)initWithNibName:(nullable NSString *)nibNameOrNil bundle:(nullable NSBundle *)nibBundleOrNil
-{
+- (instancetype)init {
+    return [self initWithNibName:nil bundle:nil];
+}
+
+- (instancetype)initWithNibName:(nullable NSString *)nibNameOrNil
+                         bundle:(nullable NSBundle *)nibBundleOrNil {
     self = [super initWithNibName:nibNameOrNil bundle:nibBundleOrNil];
+    if (!self) return nil;
+
     _device = MTLCreateSystemDefaultDevice();
+    if (!_device) return nil;
+
     _commandQueue = [_device newCommandQueue];
-
-    if (!self.device) abort();
-
-    BasicCheats.Initialize();
-
-    IMGUI_CHECKVERSION();
-    ImGui::CreateContext();
-    ImGuiIO& io = ImGui::GetIO(); (void)io;
-
-    ImGui::StyleColorsClassic();
-
-    io.Fonts->Clear();
-
-    ImFontConfig config;
-    config.FontDataOwnedByAtlas = false;
-    Font = io.Fonts->AddFontFromMemoryCompressedBase85TTF(CurvyBase85, 40.f, &config, io.Fonts->GetGlyphRangesChineseFull());
-
-    ImGui_ImplMetal_Init(_device);
-    
-    
+    _imguiController = [[ImGuiController alloc] initWithDevice:_device];
 
     return self;
 }
 
-+ (void)showChange:(BOOL)open
-{
-    MenDeal = open;
++ (void)setMenuVisible:(BOOL)visible {
+    sMenuVisible = visible;
+}
+
++ (void)showChange:(BOOL)open {
+    [self setMenuVisible:open];
 }
 
 + (BOOL)isMenuShowing {
-    return MenDeal;
+    return sMenuVisible;
 }
 
-- (MTKView *)mtkView
-{
+- (MTKView *)mtkView {
     return (MTKView *)self.view;
 }
 
-- (void)loadView
-{
-    CGFloat w = [UIApplication sharedApplication].windows[0].rootViewController.view.frame.size.width;
-    CGFloat h = [UIApplication sharedApplication].windows[0].rootViewController.view.frame.size.height;
-    self.view = [[MTKView alloc] initWithFrame:CGRectMake(0, 0, w, h)];
+- (void)loadView {
+    MTKView *view = [[MTKView alloc] initWithFrame:UIScreen.mainScreen.bounds
+                                           device:self.device];
+    view.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+    self.view = view;
 }
 
 - (void)viewDidLoad {
     [super viewDidLoad];
-    
-    self.mtkView.device = self.device;
-    self.mtkView.delegate = self;
-    self.mtkView.clearColor = MTLClearColorMake(0, 0, 0, 0);
-    self.mtkView.backgroundColor = [UIColor colorWithRed:0 green:0 blue:0 alpha:0];
-    self.mtkView.clipsToBounds = YES;
+
+    MTKView *view = self.mtkView;
+    view.delegate = self;
+    view.clearColor = MTLClearColorMake(0.0, 0.0, 0.0, 0.0);
+    view.backgroundColor = UIColor.clearColor;
+    view.opaque = NO;
+    view.clipsToBounds = YES;
+    view.preferredFramesPerSecond = 60;
+
+    // Touches are routed by MenuInteraction so the renderer itself never blocks the host app.
+    view.userInteractionEnabled = NO;
 }
 
-- (void)updateIOWithTouchEvent:(UIEvent *)event
-{
-    UITouch *anyTouch = event.allTouches.anyObject;
-    CGPoint touchLocation = [anyTouch locationInView:self.view];
-    ImGuiIO &io = ImGui::GetIO();
-    io.MousePos = ImVec2(touchLocation.x, touchLocation.y);
-
-    BOOL hasActiveTouch = NO;
-    for (UITouch *touch in event.allTouches)
-    {
-        if (touch.phase != UITouchPhaseEnded && touch.phase != UITouchPhaseCancelled)
-        {
-            hasActiveTouch = YES;
-            break;
-        }
-    }
-    io.MouseDown[0] = hasActiveTouch;
+- (void)updateIOWithTouchEvent:(UIEvent *)event {
+    [self.imguiController updateInputWithTouchEvent:event inView:self.view];
 }
 
-- (void)touchesBegan:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
-{
-    [self updateIOWithTouchEvent:event];
-}
-
-- (void)touchesMoved:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
-{
-    [self updateIOWithTouchEvent:event];
-}
-
-- (void)touchesCancelled:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
-{
-    [self updateIOWithTouchEvent:event];
-}
-
-- (void)touchesEnded:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
-{
-    [self updateIOWithTouchEvent:event];
-}
-
-- (void)drawInMTKView:(MTKView*)view
-{
-    hideRecordTextfield.secureTextEntry = KTempVars.StreamerMode; //imgui streamer mode
-
-    ImGuiIO& io = ImGui::GetIO();
-    io.DisplaySize.x = view.bounds.size.width;
-    io.DisplaySize.y = view.bounds.size.height;
-
-    CGFloat framebufferScale = view.window.screen.nativeScale ? : UIScreen.mainScreen.nativeScale;
-    io.DisplayFramebufferScale = ImVec2(framebufferScale, framebufferScale);
-    io.DeltaTime = 1 / float(view.preferredFramesPerSecond ? : 60);
+- (void)drawInMTKView:(MTKView *)view {
+    MTLRenderPassDescriptor *renderPassDescriptor = view.currentRenderPassDescriptor;
+    id<CAMetalDrawable> drawable = view.currentDrawable;
+    if (!renderPassDescriptor || !drawable) return;
 
     id<MTLCommandBuffer> commandBuffer = [self.commandQueue commandBuffer];
+    if (!commandBuffer) return;
 
-    if (MenDeal) {
-        [self.view setUserInteractionEnabled:YES];
-        [self.view.superview setUserInteractionEnabled:YES];
-        [menuTouchView setUserInteractionEnabled:YES];
-    }
-    else {
-        [self.view setUserInteractionEnabled:NO];
-        [self.view.superview setUserInteractionEnabled:NO];
-        [menuTouchView setUserInteractionEnabled:NO];
-    }
-    
-    MTLRenderPassDescriptor* renderPassDescriptor = view.currentRenderPassDescriptor;
-    if (renderPassDescriptor != nil)
-    {
-        id <MTLRenderCommandEncoder> renderEncoder = [commandBuffer renderCommandEncoderWithDescriptor:renderPassDescriptor];
-        [renderEncoder pushDebugGroup:@"Dear ImGui Rendering"];
+    id<MTLRenderCommandEncoder> renderEncoder =
+        [commandBuffer renderCommandEncoderWithDescriptor:renderPassDescriptor];
+    if (!renderEncoder) return;
 
-        ImGui_ImplMetal_NewFrame(renderPassDescriptor);
-        ImGui::NewFrame();
-        
-        ImFont* font = ImGui::GetFont();
-        font->Scale = 12.f / font->FontSize;
-        
-        if (MenDeal)
-            Menu.Initialize();  // Initialize menu only if it's open
+    [renderEncoder pushDebugGroup:@"Dear ImGui Rendering"];
 
-        // Call RenderingMenu to render the menu regardless of MenDeal status
-        UserMenu::GetInstance().RenderingMenu();
+    [self.imguiController beginFrameWithView:view
+                        renderPassDescriptor:renderPassDescriptor];
 
+    UserMenu::GetInstance().Draw([ImGuiDrawView isMenuShowing]);
 
-        ImGui::Render();
-        ImDrawData* draw_data = ImGui::GetDrawData();
-        ImGui_ImplMetal_RenderDrawData(draw_data, commandBuffer, renderEncoder);
+    [self.imguiController renderWithCommandBuffer:commandBuffer
+                                    renderEncoder:renderEncoder];
 
-        [renderEncoder popDebugGroup];
-        [renderEncoder endEncoding];
+    [renderEncoder popDebugGroup];
+    [renderEncoder endEncoding];
 
-        [commandBuffer presentDrawable:view.currentDrawable];
-    }
+    [commandBuffer presentDrawable:drawable];
     [commandBuffer commit];
 }
 
-- (void)mtkView:(MTKView*)view drawableSizeWillChange:(CGSize)size
-{
-    
+- (void)mtkView:(MTKView *)view drawableSizeWillChange:(CGSize)size {
+    // DisplaySize and framebuffer scale are refreshed in ImGuiController::beginFrame.
 }
 
 @end
-
-
-%ctor
-{
-    // Initialization logic if necessary
-}

--- a/MenuLoad/Includes.h
+++ b/MenuLoad/Includes.h
@@ -1,79 +1,18 @@
-/*
-IOS Theos Template Komaru
-Jailed (NoJB) Mod Menu Template for iOS Games
-By aq9
-https://github.com/VenerableCode/iOS-Theos-ModMenuTemp-NoJB
-*/
-
-
-
 #pragma once
 
-#include "ImGuiDrawView.h"
-#include "MenuLoad.h"
-
-#include "../ImGui/imgui.h"
-#include "../ImGui/imgui_internal.h"
-#include "../ImGui/imgui_impl_metal.h"
+#include "AppState.h"
 #include "../utils/KPatch.hpp"
 
-#include <vector>
-#include <map>
 #include <unistd.h>
-#include <string.h>
-#include <vector>
-#include <functional>
-#include <iostream>
-#include <queue>
-#include <pthread/pthread.h>
 #include <substrate.h>
 
-#import <Metal/Metal.h>
-#import <MetalKit/MetalKit.h>
 #import <Foundation/Foundation.h>
-#import <Security/Security.h>
-
-#import <os/log.h>
+#import <UIKit/UIKit.h>
 #import <dlfcn.h>
 #import <mach-o/dyld.h>
-#import <stdio.h>
 #import <mach/mach.h>
 
-#define SCREEN_WIDTH [UIScreen mainScreen].bounds.size.width
-#define SCREEN_HEIGHT [UIScreen mainScreen].bounds.size.height
-#define SCREEN_SCALE [UIScreen mainScreen].scale
-#define timer(sec) dispatch_after(dispatch_time(DISPATCH_TIME_NOW, sec * NSEC_PER_SEC), dispatch_get_main_queue(), ^
-
-extern MenuInteraction* menuTouchView;
-extern UIButton* InvisibleMenuButton;
-extern UIButton* VisibleMenuButton;
-extern UITextField* hideRecordTextfield;
-extern UIView* hideRecordView;
-extern ImFont* Font;
-
-struct GlobalVariables
-{
-    static GlobalVariables& GetInstance() 
-    {
-        static GlobalVariables Instance;
-        return Instance;
-    }
-
-    ImFont* Font;
-    ImVec2 MenuSize   = ImVec2(0, 0);
-    ImVec2 MenuOrigin = ImVec2(0, 0);
-
-    bool StreamerMode = false; //Hide the menu during recording
-    bool MoveMenu = false; //Move the menu
-    bool ShowEspOverlay = true; //Show the mock ESP overlay
-    bool ShowEspSnaplines = true; //Show ESP snaplines
-    bool ShowEspMarkers = true; //Show ESP markers
-    bool ShowEspBoxes = true; //Show ESP boxes
-    bool ShowEspLabels = true; //Show ESP labels
-    bool ShowEspHealthBars = true; //Show ESP health bars
-
-    float CameraFOV = 90.0f; //slider in MenuLoad -> UserMenu.mm
-
-};
-
-static GlobalVariables& KTempVars = GlobalVariables::GetInstance();
+// Compatibility helpers for existing feature modules.
+#define SCREEN_WIDTH UIScreen.mainScreen.bounds.size.width
+#define SCREEN_HEIGHT UIScreen.mainScreen.bounds.size.height
+#define SCREEN_SCALE UIScreen.mainScreen.scale

--- a/MenuLoad/MenuLoad.h
+++ b/MenuLoad/MenuLoad.h
@@ -1,11 +1,18 @@
-#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface MenuLoad : NSObject
-@end
+@class ImGuiDrawView;
 
-@interface MenuInteraction : UIView
+// UIKit coordinator for the overlay host, touch routing, and floating launcher.
+@interface MenuLoad : NSObject
+
++ (instancetype)sharedManager;
+- (void)start;
+
+// Called only when the menu setting changes; keeps capture behavior out of the render loop.
++ (void)applyStreamerMode:(BOOL)enabled;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/MenuLoad/MenuLoad.mm
+++ b/MenuLoad/MenuLoad.mm
@@ -1,304 +1,260 @@
-/*
-IOS Theos Template Komaru
-Jailed (NoJB) Mod Menu Template for iOS Games
-By aq9
-https://github.com/VenerableCode/iOS-Theos-ModMenuTemp-NoJB
-*/
+#import "MenuLoad.h"
+#import "ImGuiDrawView.h"
 
+#include "AppState.h"
 
-#import <UIKit/UIKit.h>
-#import <os/log.h>
-#include "Includes.h"
+#import <QuartzCore/QuartzCore.h>
 
-@interface MenuLoad()
+namespace {
+constexpr CGFloat kLauncherSize = 50.0f;
+constexpr NSTimeInterval kWindowRetryDelay = 0.5;
 
-@property (nonatomic, strong) ImGuiDrawView *vna;
-- (ImGuiDrawView*) GetImGuiView;
+UIWindow *ActiveWindow() {
+    UIApplication *application = UIApplication.sharedApplication;
 
-@end
+    if (@available(iOS 13.0, *)) {
+        for (UIScene *scene in application.connectedScenes) {
+            if (![scene isKindOfClass:UIWindowScene.class]) continue;
+            if (scene.activationState != UISceneActivationStateForegroundActive &&
+                scene.activationState != UISceneActivationStateForegroundInactive) continue;
 
-static MenuLoad* extraInfo;
+            UIWindowScene *windowScene = (UIWindowScene *)scene;
+            for (UIWindow *window in windowScene.windows) {
+                if (window.isKeyWindow) return window;
+            }
 
-UIButton* InvisibleMenuButton;
-UIButton* VisibleMenuButton;
-MenuInteraction* menuTouchView;
-UITextField* hideRecordTextfield;
-UIView* hideRecordView;
-ImFont* Font;
+            if (windowScene.windows.firstObject) {
+                return windowScene.windows.firstObject;
+            }
+        }
+    }
 
-static NSString * const kFloatingButtonPositionXKey = @"KTFloatingButtonPositionX";
-static NSString * const kFloatingButtonPositionYKey = @"KTFloatingButtonPositionY";
-static CGFloat const kFloatingButtonSize = 50.0f;
-static CGFloat const kFloatingButtonInset = 24.0f;
-static CGFloat const kFloatingButtonPressedScale = 1.15f;
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+    return application.keyWindow ?: application.windows.firstObject;
+#pragma clang diagnostic pop
+}
+} // namespace
 
-static NSString *baseimage = @"/9j/4AAQSkZJRgABAQAAAQABAAD/2wCEAAkGBxMTEhUSExMWFhUXGBgYGBgXGBUYGBYVFhcYFhcVGBUYHSggGB0lHRUXITEhJSkrLi4uFx8zODMtNygtLisBCgoKDg0OFxAQFy0dHR4tLS0tLS0tLS0tLSstLS0tLS0tLS0tLS0rLS0tLS0tLS0rLS0tLSstLS0tLS0rLy0tLf/AABEIAPsAyQMBIgACEQEDEQH/xAAcAAACAgMBAQAAAAAAAAAAAAAFBgMEAQIHAAj/xABGEAABAgMFBQYDBAcHAwUAAAABAhEAAyEEBRIxQVFhcYGRBhMiobHwMsHRFEJS4QcjYnKCkvEVFjNTorLSF1STNGSjwuL/xAAZAQADAQEBAAAAAAAAAAAAAAAAAQIDBAX/xAAkEQEBAAICAgIDAAMBAAAAAAAAAQIRAyESMQRBEyJRQlJhBf/aAAwDAQACEQMRAD8AEdkP8Vf7hheUKww9jz+uV+4YX5mcKiIpcZXHpcYmRCkU5Gu2v184hIixmkjZXkaH5dDEEMmoFRBJMDxmIIiAGbst8J4x0Ox/COEc97LfCf3o6HZB4RwiktbRlCpfesNVoyhUvuHSAQqJkzIgSlzGneRJrxmRzG8f8Vf7xjoneUjnNsP6xf7xhwCnY4n7bZ2z7xMfVN3TzhJWqgAzj5X7Ff8ArrO/+YPQx9A3lfiE/q01LVjq4eK8n6w9yYmhd8yQCcWW4/OOZ9vJ3fTFTUZMA2tNY2tV5lVBQRRM0EFzHqcHw+Pj7t7TM7vqOe2wqJLiKZdJCgWILjiIKdoJM1KyEpdJ2QvmVMJqCH2x5vPxzHKx6GOXUfRNw3ki2WJFpQwUBhmpGixQkbteBgXab1lItMqQtRHeEV2OQPmI532KnCWvuZ09UmWpKiSCQFKGST5x0ibdcqdarLOwDDLTjAWWxYTpv15R5GfxJ57+nThzeGN/roVjsolpwgk7znE8eEejqxxmM1Hk223dfO3ZD/GV+4YAzM+sHuyX+Mf3TAa1yClTHjDpRWlxrNMbS49MTEqVwti/XgaHyjRaGJGyMqQYkMolL6gMeRDHpT+GGSa7bIZsxKRm9frDBfdwmSAtJxIo/wCycq7sqx7snYymWuazlXhDaJFVFughuuuUFJMpdULSRwPv0h62C92X+A/vR0Ky/COEIty2UylLlKzSsg72155w9Wb4RwgS0tGUKd+GGu0ZQpX+aQ6QGgmp0aKyRtiwpYEvn5f19YrLnB2iKpK9I57az+sX+8fWH+Za0IS5Ijn9oU61HaSYrEqs3MoifKIzxBo61IThDnM5xyi4VgWiUTkFfIx0ld7Jcx7P/n2TDKs8pbZpNaZ7Qv31emFID1xA8oitnaGpBTSBd4q75IKdvFhw1h8vJp2YYz7M1ktoUA+of30jWalJoRAWySpqAFKThToNQBQDpBOQorozRnMpnFyqtuswZjyMOVw2pU27AtRdUmdgO5BCcP8AuMAzYUYSCSTBr9HlkPc26XNOGUUA4iWCVofU6sodI5fkcelzL7dju6fjlS1/iSk9RFmE7sHf6ZiVSFrGNBAS5HiBGQ2s3nDhHJpy8mPjlY+aLttapaypObERXnWoqU52NG0gV6xXWIm1GmiBFlKIoiY0bC1ERKl9MobIsXfJBXhb4qZOH09W5wLRaS/ukHbssqiAokA7szyP0hyUWiqJWDusPhIRRj4SSCTxdx5QwWFeJKVMxCh6sQfKMIk1S2EpISSnYDsbKJkpSlFC6XcbRqUng0aSJ2HWpvtEwjUpP+kfSGezfCOEKU+cTaVghqp/2jSGyznwjhCvskdpyhP7QGHC05QmdoFVgpQLwAgdORgIpdV/s58YOBbDJ4EXtIcKSkVWx6gPEVQFLSqcTh67oDzAyiNhMPFlsPdIKU0pU7TCRO+JXE+sXCqxdksqnS0jU/KHG1WIJDldYUrlS8+WN/yjpNgudClYplUpDqfZHofFzmGGVp40Fs1w96y5rpRRtq9aD5xeQJUsNLlgAZmvnvpBudKKjXPJI/CGblrAu8LIwL++Ajh5ubLOtPbICZoIGbGnzEVZ9hmywVKSSgfeAp5RUs00oWkjT3X0jsfY4yplmKVhJS5BdtQ48j5RGPyrw963NqnTjy7cRRIrEEy3Te6mIxkJVVQBLKI2iGTt/cQs0zHLrJWaEaHZCrYlY1KfKO/znJqt9ag12MvBQmSlywCtPiY0BKQSR5GHT/qhP/7VH/kP/GOTXRaMM8y3IGKm54ff7o2j/LP+n6xz8lxxvYmPnOyhKz6xBM1ieTn1iusxz1xxTC9sbqRSMBD1H9I3SWDeUINrBOwrHhxPRiHz3Q6WK0zW8UtsmCAQWGVBX5QEuC5isiZiZANcg+7P20P9lu8FIL1GtajfvqTzi4mtrHaCUoKg3E7TtzfLrGlpZlAOCWz8i/ukFZaEsBQkUNGcZ6a0gbeEsFRDiuXIFgdxp1iilKF6XgZVqWTkyeYwiGSV2llFICSSQKhjnAi87vlqLr+Lw6ndTyMBzakpIQAwc02kt6EjrE6Ue0XihSHcZQr32sKVSBC7WgByS9CoDMtWmzSsUxbFsSxbfs2mAtD922YLLEs1YDWq0spS9gpyJA9BFm7bStVXCUF/Fk22LNuuxISjD4iRiJ0bQnd9IVx2Zf8A7ROHCaqYk7B7rCjNHiPEw7WixJQ7uMgzaNTnQdYoTbnQsulTUOegfPzhzQsALrxd6jCHLluLP8jHZJcsoQlAHiNVcH/pCj2YucS54JYhNDtYB8R5jIZPqcnGzVW5yIPMAmpOw0pF3K+PiIns9iZOfD5awNvG76E+z1g+mgrFS3LBFacT7eI8YrdIdokkEjWHvsnav1CpRPiUkFP7ySX8iIV7ZLrRjo4+mkTWQzUdxMQHwqVib8JZ6RGOO7ppL6OV9WELsU2UoucONJOih7Eccss8AUzzMdgvKzfaQmViKApgSM2Mc9vLsZMRb/sNnBWSAQTklOqlHQCJ+Dy+O8cr26Jjlcd0BmXtKGFKZIC38S3qWyakdJ/t20/5h6GET9IfZVN3TZSBO7xSkuqgGFm00ziL+9U78fkmOjk1yavsY3SWVn1ivM1ieXn1ivM1jKuGIJR1ixLS5oW2/URXs6a5jqPnFtEuozHulYRme47MZbYg8tQdJFU/tAtlxyppV2OyHASA5DOkvQiA3Zezqlgg5FzhPm2x84ZrJZ0BPNxuyceUa4xFrZb9A4I1Yv74mKtqUwU9SD6EFvI9Yu2iYAHGXyIb5jpAVdoClKVmfCW02PFEX7ytJVM7tIOIrSzGoc06EiK17ysMlChRaglxqCT4lef+mK932eYq8VqqyEqUpzoCFH0Bgl208A8PiUoskZ0ICn6nyiFFtCe9tIQgPlzyB9B1MHF3SlEuYgkkhClFjsGnRoI3Jd6bOhM1XxgZlsyApx0PWBl5TVzFpVKcAIW+uIAAihzrT+IQgCW20rmlMtIZOBgE5jCQB1wnrDjd8rCnxAkhxuwgrwjiA3URJdd2yxh8LEaipAdJSx4kGLvcUCEjj/ECKnXTrDCjNupM9WIp+IAucmFBnwMaXhciQHGZyYa6KbaMh/UhjkpCQDVmoNNPoI9PSkEKPED3lT1hHspXfYVSjhUfGsu2ZCWZjzd+EHrOA/hLsSP6RObOKzGCVKbEdWAYJHD5xrJIL4SCMmGmjb9YSpVjEcyC3WK1osgVtSdm/QjYekXkpAzDcCw41PnEyVJP7QZ6MW+nKHCpJtEsiY2uu3gYe+wV0JmyZpWP2UniM/SBtuulK6oUH2FuLBWufn1av0f4Uy5kr76CnENQ6cQ9YMdy7h27mi52euy0zVy5apa5YlPjmKBwrMtWEYTq+cO18FNmlzbSmXimEAEgOotRIYVNTlvguDSFjt72nN3y5U/DjBXgMvLE4JBxMWZvOFOOZZbk7q7z5dS+p9OdXx+jC2WubKnzp6QZ6vEAlRMlJSVsa1NG2OYt/wDQpH/er/8AEn/lHYUFwDG0XMtSSIy5Msrba+X0HxHnFdesTo+I84rzDnGdSrpz4/lBa7LD3iwlylw4LeF8w8b9nrvCzjUKDzI3Q1CQnDQgEavhP9eLw5Bttd2KTLAWfEMzm4B2/ebbBSx2130UnMGgNKf1GyAFunKIwsS2dAx3hsjn58Iu3WCmW+LEPunOmgfMZfCoUL1L0uVNT3zbhQD7xHUliOpERGyd0mp8R1fLEoM/QdIASphn2hx90u28HJtRnF3tDfOFcsM74k8dteDdINjSqi0CzKmTl5zQ2ygcAA7/AFi5YV96kzZgAqyXzDhVQ+9+kL94JMyzzJ66pxApA/y8PxAbMTfymJbiQuZhkEqDDETXWiQCdpPlCMxIsirTOSxaWCokMXWAkBLbBUiLpsYQlKmqkFI3F8RPRKf5RB2yWVKUJCRVCEjiAhoCdqbVhlFmemylXI3QEglLYqKSPEWA2HJ/nzEFbBQl8yAeZy9Hha7Py1EBai7VFc6ipb2wEMcuaAH1ep984DWZp020DbB7eIFywVV0d+OZ4ankI3l20EYaZU4BvbR5BBdNal1erPwb2YQQLl4npTmABrXU1+UaiSJYYFidWruAHtouTVpCXoAK7gNOukDJsyYskpS2TYs2/FwDkwjYt8oKSygpWVAWP8Sg1KfSBQtS0qPwy0J8LggqHAkFuBOsMFmk0clzUsNu19TXOJbNc6EOkMEkFxs3vocoVlXLASTfCpaFTJqipCXzFTVkgavpBnslf2CdOWpQpLcudMWZ1DbOmcLV8SQtaZIHgTU18yNsWuz8+zp+2CaQjvZaZYUzsVqwjeM32UrD4u8tU8rJ3rZjtv6UJVnQapnEZAFjwcUjmvbj9IM68kolqlolS0KKgEkqJUzAlR2AnTWO+XfcFml2VEhKEGWmWEhTJqAlsZVtObx883OizS73loIE6zi0BABYhYUcCS2RAUoHYWjo4sZJbPoZ8kzy346dD7E9qL7tUn9VIkLQgBPfTgtGNhkGPjO0gNBf+1e0H/a2X/X/AM46IhAAAAAAyAoAOEbNEec/1jKx8uo+I8TEMzWLCpRCqgjiDFG2uxHvkYxVpeuu+0yUhJJdzoWrthjRe6FJcKelcQcEfvac4WbN2cxSwVFlGvsREbIuU4CyRllFARvbtGJVQC+4/WJrq7VCekpBwqbIs7/MQqTpOIKmTC6UuA+3U74DC1qCsSPCRk2cELp0i6h3cxRcAk0bfTb5cOcy5HezMZ+58LftIUNcs/KB9z27vZWMBlBqZudldDThygv2dc4iQ9HG4DCUh+XusAELHZUmyqCUsEAlmd04WIH8RJ6xH2bsxQqanLAvwnVsKSlJOyim4DbBywSQmUwyeu9NX6V6wMksCQxfwpLlnyDH+UMdsLY0PzbZhQSTl6PQfLlHPL2tirTOwD4QHPvk0NF6DwsxyFNxbTbUg8oEXeEywS1cID7xR4NiQXsSUSpfiIA37W99IXr5v9ajgkhwD8RfPLIc4rXtflncpmKxEaYtaHIU9aRtds6XNBLAk0cUJDuwSMv3m6QbGk1y25dMYOwqOzbuqOG6HWQrwuXAIpqTzPXrCt/Z6aHGQMwnxZtvDk+cMFiXhSxL7C4ccQDSCGtrQSxNdgoAH+8Tpr7z0VLFAfExzLsDuAqT574symOYry014RupAGUPRKptDAlqDl0T9TESLzUrwhFSCz5AfiPXKJJyCauWG8joGrFZKxvIGgyfkc+WkAAr1niWDUkuCVMa7gNkArgvSUmeZ09BmSkrSVIZyUg08OtWLatDLeoQtWBIBOtS7bAeeUL173BgStaaOkhhtFdOELHrLat7mnQJX6arH3i0LkzUygAEEJBKvxYkP4Rk0cp/SF2hkWq199ZZZlICUhNAlRUC+Jknw7uEJkxRcxrijox5Jj6iNPoqR+mS7pUhGFE9czCHRhLhTVBmLLGuoeBP/Xn/ANl/83/4jheKM4oneP8AC06rOtAgDeNSGbfHptoJUwaI1JKify+scmLs5fRiu2ZilpFaUpu2tFa9JbJUsaA+msD7JeRltub6ZwcUpE2UQGZQLEHqKZRq5SPe1sUbHJl0wh1byqYEYif5BC+k0g2EUNmmUUlwl/vJNfzEUZV2KxVZvWKiTZ2eWcOMgB8IISGFPC7by380OHZvNYOx+D0hNuu0+JMlO3Es6MAWTzOE/wAMP3ZmQSlStVkjkKCC9nPRiuOQ4Or6dYrXxYQk4xl+fq59tBq6ZOFDEV/OKV/o8SSD90uNrEH5ROj32Wbbk3roXCvlHOr/AL0XPmqkWcshNFKG7foPz3w09vbx7qUQ/iNE9AyvMwr3NZsFj7xnKyVHeASAOg84WhbqFyfZpaCzlR96RLYXSrFKUUqFWOUVO+xEnbWC/Z62S5dos8xTFlqEwLCVIAIAQrCRVsRNdU7ovW0eVM/Z7tBXBNSMTavXe4+J4drFbHDpIY73yzGfqIQu1lnSlWIHJiOBIA97hHrqnzwkEBwWbY4p6RPqtJ3NupyJuIVPQ/WJVpB18398o5yL0taC6gAkagnL+Exdsvas6vrqz8ywh7LRymBhQN1rxMDLV8TAMRXMAV2PnxjFmtypgoxyq4LV3RVvJCsNE4sswaf6Q2sIRTvAkHElQDGpcVB5N0i7Z5qJiCGBptB06xDZ5bpLjyrwAL0jWwJYFLij8SIFOQ3tYiidMToFH1iiUGHS+fDNWCNTmIHKIP3UmLRS20eaGHu0fgTGcCPwJgDaSsk7esW5M/CdNIFSJBcU9YuWizEswJ6t6RjHRnVxUrESAplZttEZsyVILpUUnZorc238o2lWBZSlSSQoa002xfstnmLLFSTuAGmrtFsqgnIROAE+X+6rI51roImldmZLP3qyNmL2YYbDddHwgOa5lztopvIRvOu1a2SkMDnSiRt/J4NJ2XeyVymZNmJlv3KVVLGpYhgdc46rcd2KSrRkjTfSMdnLvQhASkMBs1O3eYZbPLAFMzGkia0lSWqBAe+5uBQxMzFj5kk8PSGhO+E39IKFdy6CzuCzv1GucF9FPbkHb21/aJqiCfClhlUpzr58omuBYm2JUv70skttlq+iiochti7ZrgRNICyaMzE1cgKUdo8JiW0dlDLPeWSbgWBUGqVPQpI95RnKvKbjnNrshlqKTk9DtET3ZZipWLQdDDhbbFPUfHZHUDnLXLKTvwrZnaNJdyzlEghMlPEKVvYDwjzito1VOYF2lYQHIBClnhVKeOXIQ12CzgJZhRhl6anZFST3MhOBLcPE5c1JJzPExess8FsttaDoIja5OhtNnlkVTpz5bIVb87Pl8csNuerfLrBoTipsL7KPFqTZ11CnZt3UQzJlx3kZKikhjrk/mIa5to71BCWPDZnprygN2huRgSne71b6cRGvZwADCo4lZNkXGkBjEqdoTlpTLcdsTLlpd+j0J86wJCSia4BSDmHf3TbBU2gEVSemXKEIUu1tkVjK0oxBgS2mjQqfaf2Y6hPUg51BGo0bKOeX/Y8E04cjlG048vDy+mGXLj+Tw+w82/8AZMe+3boiWBrEXhiNtBaxylrOJlNuBaD8ixKUnIgjrAm7VTFh1EE/zeeXnDHdqWofQD6vGTps6UV2RQHhC34/QGLd3qUmpK/4mHo3pBRVnGwdIjl2YA5dABBtloUuuYSal+LekE1zmpk8D7GgAUV1i3aZboLZ6RcqdDVjvJKQAPlB+wWsNnHO7vtGJgRUFiN49vF6f2ml2eYJZlzFEh3SEsN1VAnkIJn22vFNOhLnPlnFJViCkrCy4UzjRxChd18WuZMSpMsIlKUHxVXh3tQefGHReLDv90i5XPnjqud3qruiQM5ZYtUsVAim8P0hetMknxBSsy7PStc22lxDvfFz4lKVVyGI0Oee3MiFa23WapBKXqHKiRXQVbIflSIpwBVPmMwmLIyOZID64hWg2UrwiGeZmWJxxHDMhwYvzbKtWaiSMtvAnJ6RiTKm1/UV2hgDvOReEeg+VZ1ggrBfYCqnPM6QYlyqYlKIGzIcK5xtZ5U12KAl9rkJ8vrBiy3Un4lN5kQja2K0kgBKabdPKCyp5SKh8qVfg0QTbRLlCpS+YB13pH0eJJVp7wuGOzVuNIYUbxU8tkgEkHJwdoI308oRZRVZ57lyk8n4g+uXCOiKsxKiCwGhG19p5QPvq5kzHSoDFodeQaGFey2xKsyxORJSaaZPwzi4LYgVc0Ghc9GhONxqQQyiz72biIKXfdqkrqo14FvnCC5PUZhOAuODVgHb7ifxHETD1c6JQKsZB3M3QwbQmzHMRrMv1kZXH9t6cFvK6lIL4VNwMD+5P4VdDH0Wq77IqI/7Fsm7yhdDtxCzW1WSQ24aczlBWwTyFBz/ACiBllszCsEbPLUosnnoOcYO+49GySoEBo8pLZRVsDppBFSXEDBtJUNfKLspT0eBaaRZlrA1h7LSG8gZSu8FUk14jPy9IPXVd4ntOWkPoDsYMYXbfa0sxVlBO4rzLBi4FG3Q40uV8dH6wISlDbPL8otqLjwtzgPY7ySWBo+hiynC4Y8uMabc1jNqsxP3QdsCrfdoNCmm3YdoOkGUUNFPu2RMHObGJpxy++LjW+vEVfUEj5/SBtnk2lCmQEkV2gHk/Dzjq9qu4Kq1Wb5wNXdu5/M/WIvS5dkf7ZPoVIQkjNyR5jKPT50xSaKbY1Oh16coaLbdIVXI+6bYC2i7lpVRLjUD6Zwtq1CTeN3T0qfGpYOrvrkQae84I2C+1yGCk01VU+X3T7EMkqTu3eXrEc+6UlLBI+vvaIcpaGrsvFMxIUGLjTUatEFvSlsST9Q27pCqLsnSye6PhNSHYjeA1eOW6CVmsKnKlrJ3HKn+3XdFbTpCbRjWSxG9gxi5iKRizGhABd9o/IRNJlE0AYUzZhuGnKB3aK9EoZCUgkZg0+dDAaZFrSMx73GJhbEwnT7+UCWT/CuofcSKc+sQJ7T/AIpI3sWgTqnxNsTG32tO0wjJ7TStZShwP5xv/eSR+GZAXbNkusryg9YrsCBlF65rGyX+TQTMmJ03zz3Qg2aPJlkQUXIjQyISNhcxMQqQ9IIzpMVFyzAambEC8bSLKpJdO54vWQ1grZJIJaA9tLDeBFFDnDBYrSFB9YoiwpMWrLZgMqQbouhNCxm35xOFjSKCJW+LKZO+DadLBn08NY0HiqR0jMtAHGNnaDZIZkp9/H6xWXYgcuhqOX5GCCaxMEQAt2q7c8/X8xzBED5stQ9+Y2w6GQD7rFS0WM8R5/nD0NkecCulRpR689DxiazXRiAxvT3t9IavsI0H1ivaLOlDFRAG/nlvg0NhE9SZSCHbR8hXQ7PSEK/5oWGWzvRTUPCvhVzTwUIK9qL5KSQCDKq0xOJ0H8K05FPlVoQrbaFB1oZxRQTVJSdQk5AHMVAcNTKk7aWhLZF9N4bQ+UQhOvUa8RtiAW5xlUV4jUe98afaxshHtYKIxhjRNqB5ekY+0p2ww7rZZIApFg2Z4jQkgwRkiDRbUEyWjSZJgt3MVZyGhaGwiZIiuuzQWwxCtNTSFo9ga5JESyrQoGCIlOffpGq0IGYaFo9rFivF3cReE0EA5QCNoDslOJsohtRmzM1MNiadYzy5MZ9tMcLTAq9ZUssqYH2a6fWLF331KmJdKwQ7bwafUQh2q6ziC9QGfq9eZgT9mXLLoJHtx5xn+aL/ABOyyaxbCRHOuzPaTC0ua+5X15PDlZ7alTMsHXPbkI1xzlZ5YWCmBolSmKSbVvidM7KLlidJxGzxWVaBEEy2bILnIJhanttpTLSVH5DzOUc37V9oEzErlT0qDVxJDKSCzKA1FfYLQ7TVvQ1Ecq7ZyTInETAruFA4Vp+KXwzFDozHY5BBjnLdHlhqFm1zFJPiXiChRY8QWBlib42GvxAGoDhgk9ZQSDQKToXGhBBBycJPAxctOOSX8M2Qti4fAqrA5+BQL8C4dwWgtaUlIU5XJJYLYd5KUalMwChPkrMEFwNWQWVRh4lnWcgsCDrTUHIga8niKEEiCw4v6fU+URxIoabPZjzQw+i1iLdlilOVGZM+EBc5RWmiM/bEipLcYoWi8gfgBO/IfWFlnjj7oxxt9RtOijMntv8AXpHpqlq15Cn5x5MoDSOXP5E/xjfHh/qJGInZ6xt9mepJPH6RaQIyRsjDLkyy91tMMZ6iJEmNlSYsYY1bV4zWrKkRRn2AHSC5EeVLgBYXd7HKJZUpQycfKDy5Lxp9mEVKFSStbu5grInKLOTx+RiGXZotypcXMqVkWkKOcSu4iFGUbRWy08DFC+7rRaJRlr/hOeE7W1GhGoi/GDBLorHz7aJUyyTZkpafCC0yWas9BMQ+aTRjr8KtCYMAlkrl+KWR40VPgOSw9VJ8xkWq3ZO23ZoWuU6GTPQD3ai1dstW1JyrHF8CwooYomIJ8ORlryKa5oVluLPm6uzDPyjlzx8agnywKP4CfCc8CjXCTqkir6hjmCIrFJTnQ7PnFzvUkY28PwrQH1qkpfIAuRsZss681NcJLn7pyCk6Ddu2ZcLShBjOKNYzDJ9DTLSCGYkxGMWWXvbEqU0jKUUjzsufLL/jrx4sYi7r2YlQjdEhAjViPekZNHmjZIjYGPNAGGjLRlA2xu0AaiPaZRkx7hWAMBMZR7MbR4QBnu4zhjd6RkjKGGiExKI0TsiQDSKhNhG0YCo88M3oxHoxDJ4xzz9JfZUzAbZIH61A/WJH30AMVNqQMxqI6GqIzFY5XG7hZYyzT5tXMBOPRYIUBocyR5KG+IxVOE5pqOH3h/8Ab+bbHYu0nZmS+PuklKjWnwq+mcK83stIJdIUk7ifQx0zllYXipCUp4xDbP7G/gm/zD6RV/ufN/Gjzi5nj/UfjydpSGjZj1jCDWJE6mPLdrUltI3puiJZyiQHKGTAEYMZV8o8nWAPCPARs0eUIA8DWsZA0jwEbQw8Y8Iyg0jBgJsDEgMQysjzjdPyhhI2yMxqI2GcBspjIjVMehhtGGj0eJhhq8amNjGFQEinSwoFKg4NCIUrzu8ylbUn4T8jvhxIgfe4dJSajCo8wzHzipQUWjLRlQj0WH//2Q==";
-
-@interface MenuInteraction()
-
+@interface MenuInteraction : UIView
+@property (nonatomic, weak) ImGuiDrawView *targetView;
 @end
 
 @implementation MenuInteraction
 
 - (BOOL)pointInside:(CGPoint)point withEvent:(UIEvent *)event {
-    CGRect touchableArea = CGRectMake(KTempVars.MenuOrigin.x, KTempVars.MenuOrigin.y, KTempVars.MenuSize.x, KTempVars.MenuSize.y);
-    if (CGRectContainsPoint(touchableArea, point)) {
-        return [super pointInside:point withEvent:event];
-    }
-    return NO;
+    if (![ImGuiDrawView isMenuShowing]) return NO;
+
+    CGRect menuFrame = CGRectMake(
+        KTempVars.MenuOrigin.x,
+        KTempVars.MenuOrigin.y,
+        KTempVars.MenuSize.x,
+        KTempVars.MenuSize.y
+    );
+
+    return !CGRectIsEmpty(menuFrame) && CGRectContainsPoint(menuFrame, point);
+}
+
+- (void)forwardTouchEvent:(UIEvent *)event {
+    [self.targetView updateIOWithTouchEvent:event];
 }
 
 - (void)touchesBegan:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event {
-    [[extraInfo GetImGuiView] updateIOWithTouchEvent:event];
+    [self forwardTouchEvent:event];
 }
 
 - (void)touchesMoved:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event {
-    [[extraInfo GetImGuiView] updateIOWithTouchEvent:event];
-}
-
-- (void)touchesCancelled:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event {
-    [[extraInfo GetImGuiView] updateIOWithTouchEvent:event];
+    [self forwardTouchEvent:event];
 }
 
 - (void)touchesEnded:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event {
-    [[extraInfo GetImGuiView] updateIOWithTouchEvent:event];
+    [self forwardTouchEvent:event];
+}
+
+- (void)touchesCancelled:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event {
+    [self forwardTouchEvent:event];
 }
 
 @end
 
+@interface MenuLoad ()
+@property (nonatomic, assign) BOOL started;
+@property (nonatomic, weak) UIView *rootView;
+@property (nonatomic, strong) UIView *captureWrapper;
+@property (nonatomic, strong) UIView *overlayHostView;
+@property (nonatomic, strong) UITextField *captureTextField;
+@property (nonatomic, strong) ImGuiDrawView *imguiView;
+@property (nonatomic, strong) MenuInteraction *touchView;
+@property (nonatomic, strong) UIButton *launcherInputButton;
+@property (nonatomic, strong) UIButton *launcherVisualButton;
+@end
+
 @implementation MenuLoad
 
-bool isOpened = false;
-
-- (ImGuiDrawView*) GetImGuiView {
-    return _vna;
-}
-
-- (UIView *)hostView {
-    UIApplication *application = [UIApplication sharedApplication];
-    UIWindow *window = application.keyWindow;
-    if (!window) {
-        for (UIWindow *candidate in application.windows) {
-            if (candidate.isKeyWindow) {
-                window = candidate;
-                break;
-            }
-        }
-    }
-    if (!window) {
-        window = application.windows.firstObject;
-    }
-    return window.rootViewController.view;
-}
-
-- (CGRect)floatingButtonBoundsForView:(UIView *)mainView {
-    UIEdgeInsets safeInsets = UIEdgeInsetsZero;
-    if (@available(iOS 11.0, *)) {
-        safeInsets = mainView.safeAreaInsets;
-    }
-
-    CGFloat minX = safeInsets.left + kFloatingButtonInset;
-    CGFloat maxX = mainView.bounds.size.width - safeInsets.right - kFloatingButtonInset - kFloatingButtonSize;
-    CGFloat minY = safeInsets.top + kFloatingButtonInset;
-    CGFloat maxY = mainView.bounds.size.height - safeInsets.bottom - kFloatingButtonInset - kFloatingButtonSize;
-
-    if (maxX < minX) {
-        os_log_debug(OS_LOG_DEFAULT, "Floating button horizontal bounds collapsed; falling back to minimum x.");
-        CGFloat fallbackX = fmax((mainView.bounds.size.width - kFloatingButtonSize) * 0.5f, 0.0f);
-        minX = fallbackX;
-        maxX = fallbackX;
-    }
-    if (maxY < minY) {
-        os_log_debug(OS_LOG_DEFAULT, "Floating button vertical bounds collapsed; falling back to minimum y.");
-        CGFloat fallbackY = fmax((mainView.bounds.size.height - kFloatingButtonSize) * 0.5f, 0.0f);
-        minY = fallbackY;
-        maxY = fallbackY;
-    }
-
-    return CGRectMake(minX, minY, maxX - minX, maxY - minY);
-}
-
-- (CGPoint)clampedButtonOriginForOrigin:(CGPoint)origin inView:(UIView *)mainView {
-    CGRect bounds = [self floatingButtonBoundsForView:mainView];
-    CGFloat clampedX = CGRectGetWidth(bounds) <= 0.0f ? CGRectGetMinX(bounds) : fmin(fmax(origin.x, CGRectGetMinX(bounds)), CGRectGetMaxX(bounds));
-    CGFloat clampedY = CGRectGetHeight(bounds) <= 0.0f ? CGRectGetMinY(bounds) : fmin(fmax(origin.y, CGRectGetMinY(bounds)), CGRectGetMaxY(bounds));
-    return CGPointMake(clampedX, clampedY);
-}
-
-- (CGPoint)defaultFloatingButtonOriginForView:(UIView *)mainView {
-    CGRect bounds = [self floatingButtonBoundsForView:mainView];
-    CGFloat midY = CGRectGetMinY(bounds) + CGRectGetHeight(bounds) * 0.5f;
-    return CGPointMake(CGRectGetMaxX(bounds), midY);
-}
-
-- (CGPoint)storedFloatingButtonOriginForView:(UIView *)mainView {
-    NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
-    NSObject *storedX = [defaults objectForKey:kFloatingButtonPositionXKey];
-    NSObject *storedY = [defaults objectForKey:kFloatingButtonPositionYKey];
-
-    if (!storedX || !storedY) {
-        return [self defaultFloatingButtonOriginForView:mainView];
-    }
-
-    CGPoint storedOrigin = CGPointMake([defaults doubleForKey:kFloatingButtonPositionXKey],
-                                       [defaults doubleForKey:kFloatingButtonPositionYKey]);
-    return [self clampedButtonOriginForOrigin:storedOrigin inView:mainView];
-}
-
-- (void)persistFloatingButtonOrigin:(CGPoint)origin {
-    NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
-    [defaults setDouble:origin.x forKey:kFloatingButtonPositionXKey];
-    [defaults setDouble:origin.y forKey:kFloatingButtonPositionYKey];
-}
-
-- (void)applyFloatingButtonFrame:(CGRect)frame animated:(BOOL)animated {
-    void (^updates)(void) = ^{
-        InvisibleMenuButton.frame = frame;
-        VisibleMenuButton.frame = frame;
-    };
-
-    if (animated) {
-        [UIView animateWithDuration:0.2 animations:updates];
-    } else {
-        updates();
-    }
-}
-
-- (void)updateFloatingButtonVisualScale:(CGFloat)scale animated:(BOOL)animated {
-    CGAffineTransform transform = CGAffineTransformMakeScale(scale, scale);
-    void (^updates)(void) = ^{
-        VisibleMenuButton.transform = transform;
-    };
-
-    if (animated) {
-        [UIView animateWithDuration:0.18
-                              delay:0.0
-                            options:UIViewAnimationOptionBeginFromCurrentState | UIViewAnimationOptionAllowUserInteraction
-                         animations:updates
-                         completion:nil];
-    } else {
-        updates();
-    }
-}
-
-- (void)snapFloatingButtonToEdgeAnimated:(BOOL)animated {
-    UIView *mainView = [self hostView];
-    if (!mainView || !InvisibleMenuButton || !VisibleMenuButton) {
-        return;
-    }
-
-    CGPoint snappedOrigin = InvisibleMenuButton.frame.origin;
-    CGRect bounds = [self floatingButtonBoundsForView:mainView];
-    CGFloat leftDistance = fabs(snappedOrigin.x - CGRectGetMinX(bounds));
-    CGFloat rightDistance = fabs(snappedOrigin.x - CGRectGetMaxX(bounds));
-    snappedOrigin.x = (leftDistance <= rightDistance) ? CGRectGetMinX(bounds) : CGRectGetMaxX(bounds);
-    snappedOrigin = [self clampedButtonOriginForOrigin:snappedOrigin inView:mainView];
-
-    [self applyFloatingButtonFrame:CGRectMake(snappedOrigin.x, snappedOrigin.y, kFloatingButtonSize, kFloatingButtonSize) animated:animated];
-    [self persistFloatingButtonOrigin:snappedOrigin];
-}
-
-+ (void)load {
-    [super load];
-    timer(3){
-        extraInfo = [MenuLoad new];
-        [extraInfo initTapGes];  
++ (instancetype)sharedManager {
+    static MenuLoad *manager = nil;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        manager = [[MenuLoad alloc] init];
     });
+    return manager;
 }
 
--(void)initTapGes {
-    UIView* mainView = [self hostView];
-    if (!mainView) {
+- (void)start {
+    if (self.started) return;
+
+    UIWindow *window = ActiveWindow();
+    UIView *rootView = window.rootViewController.view;
+    if (!window || !rootView) {
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW,
+                                     (int64_t)(kWindowRetryDelay * NSEC_PER_SEC)),
+                       dispatch_get_main_queue(), ^{
+            [self start];
+        });
         return;
     }
 
-    hideRecordTextfield = [[UITextField alloc] init];
-    hideRecordView = [[UIView alloc] initWithFrame:CGRectMake(0, 0, UIScreen.mainScreen.bounds.size.width, UIScreen.mainScreen.bounds.size.height)];
-    [hideRecordView setBackgroundColor:[UIColor clearColor]];
-    [hideRecordView setUserInteractionEnabled:YES];
-    hideRecordTextfield.secureTextEntry = true;
-    [hideRecordView addSubview:hideRecordTextfield];
-    CALayer *layer = hideRecordTextfield.layer;
-    
-    if ([layer.sublayers.firstObject.delegate isKindOfClass:[UIView class]]) {
-        hideRecordView = (UIView *)layer.sublayers.firstObject.delegate;
-    } else {
-        hideRecordView = nil;
-    }
+    self.started = YES;
+    self.rootView = rootView;
 
-    UIWindow *window = mainView.window ?: UIApplication.sharedApplication.keyWindow ?: UIApplication.sharedApplication.windows.firstObject;
-    if (!window) {
-        return;
-    }
-    [window addSubview:hideRecordView];
+    [self installCaptureHostInWindow:window];
+    [self installRenderer];
+    [self installTouchRouter];
+    [self installLauncher];
 
-    if (!_vna) {
-        ImGuiDrawView *vc = [[ImGuiDrawView alloc] init];
-        _vna = vc;
-    }
-    
-    [ImGuiDrawView showChange:false];
-    [hideRecordView addSubview:_vna.view];
-
-    menuTouchView = [[MenuInteraction alloc] initWithFrame:mainView.frame];
-    [mainView addSubview:menuTouchView];
-
-    NSData* data = [[NSData alloc] initWithBase64EncodedString:baseimage options:0];
-    UIImage* menuIconImage = [UIImage imageWithData:data];
-    CGPoint initialOrigin = [self storedFloatingButtonOriginForView:mainView];
-    CGRect initialFrame = CGRectMake(initialOrigin.x, initialOrigin.y, kFloatingButtonSize, kFloatingButtonSize);
-
-    InvisibleMenuButton = [UIButton buttonWithType:UIButtonTypeRoundedRect];
-    InvisibleMenuButton.frame = initialFrame;
-    InvisibleMenuButton.backgroundColor = [UIColor clearColor];
-    [InvisibleMenuButton addTarget:self action:@selector(buttonDragged:withEvent:) forControlEvents:UIControlEventTouchDragInside];
-    [InvisibleMenuButton addTarget:self action:@selector(buttonTouchDown:) forControlEvents:UIControlEventTouchDown];
-    [InvisibleMenuButton addTarget:self action:@selector(buttonTouchReleased:) forControlEvents:UIControlEventTouchUpInside | UIControlEventTouchUpOutside | UIControlEventTouchCancel];
-    UITapGestureRecognizer *tapGestureRecognizer = [[UITapGestureRecognizer alloc]initWithTarget:self action:@selector(showMenu:)];
-    [InvisibleMenuButton addGestureRecognizer:tapGestureRecognizer];
-    [mainView addSubview:InvisibleMenuButton];
-    
-    VisibleMenuButton = [UIButton buttonWithType:UIButtonTypeRoundedRect];
-    VisibleMenuButton.frame = initialFrame;
-    VisibleMenuButton.backgroundColor = [UIColor clearColor];
-    VisibleMenuButton.layer.cornerRadius = VisibleMenuButton.frame.size.width * 0.5f;
-    VisibleMenuButton.layer.masksToBounds = YES;
-    [VisibleMenuButton setBackgroundImage:menuIconImage forState:UIControlStateNormal];
-    [hideRecordView addSubview:VisibleMenuButton];
-    [self applyFloatingButtonFrame:initialFrame animated:NO];
-    [self updateFloatingButtonVisualScale:[ImGuiDrawView isMenuShowing] ? kFloatingButtonPressedScale : 1.0f animated:NO];
+    [ImGuiDrawView setMenuVisible:NO];
+    self.touchView.userInteractionEnabled = NO;
+    [MenuLoad applyStreamerMode:KTempVars.StreamerMode];
 }
 
--(void)showMenu:(UITapGestureRecognizer *)tapGestureRecognizer {
-    if(tapGestureRecognizer.state == UIGestureRecognizerStateEnded) {
-        BOOL isShowing = ![ImGuiDrawView isMenuShowing];
-        [ImGuiDrawView showChange:isShowing];
-        [self updateFloatingButtonVisualScale:isShowing ? kFloatingButtonPressedScale : 1.0f animated:YES];
-        [self snapFloatingButtonToEdgeAnimated:YES];
+- (void)installCaptureHostInWindow:(UIWindow *)window {
+    UIView *wrapper = [[UIView alloc] initWithFrame:window.bounds];
+    wrapper.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+    wrapper.backgroundColor = UIColor.clearColor;
+    wrapper.userInteractionEnabled = NO;
+
+    UITextField *textField = [[UITextField alloc] initWithFrame:wrapper.bounds];
+    textField.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+    textField.backgroundColor = UIColor.clearColor;
+    textField.borderStyle = UITextBorderStyleNone;
+    textField.textColor = UIColor.clearColor;
+    textField.userInteractionEnabled = NO;
+    textField.secureTextEntry = YES;
+
+    [wrapper addSubview:textField];
+    [window addSubview:wrapper];
+
+    UIView *secureContentView = nil;
+    id delegate = textField.layer.sublayers.firstObject.delegate;
+    if ([delegate isKindOfClass:UIView.class]) {
+        secureContentView = (UIView *)delegate;
+    }
+
+    self.captureWrapper = wrapper;
+    self.captureTextField = textField;
+    self.overlayHostView = secureContentView ?: wrapper;
+    self.overlayHostView.userInteractionEnabled = NO;
+}
+
+- (void)installRenderer {
+    self.imguiView = [[ImGuiDrawView alloc] init];
+    self.imguiView.view.frame = self.overlayHostView.bounds;
+    self.imguiView.view.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+    self.imguiView.view.backgroundColor = UIColor.clearColor;
+
+    [self.overlayHostView addSubview:self.imguiView.view];
+}
+
+- (void)installTouchRouter {
+    MenuInteraction *touchView = [[MenuInteraction alloc] initWithFrame:self.rootView.bounds];
+    touchView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+    touchView.backgroundColor = UIColor.clearColor;
+    touchView.targetView = self.imguiView;
+
+    [self.rootView addSubview:touchView];
+    self.touchView = touchView;
+}
+
+- (void)installLauncher {
+    CGRect bounds = self.rootView.bounds;
+    CGPoint initialCenter = CGPointMake(CGRectGetMidX(bounds), CGRectGetMidY(bounds));
+    CGRect frame = CGRectMake(0.0f, 0.0f, kLauncherSize, kLauncherSize);
+
+    UIButton *inputButton = [UIButton buttonWithType:UIButtonTypeCustom];
+    inputButton.frame = frame;
+    inputButton.center = initialCenter;
+    inputButton.backgroundColor = UIColor.clearColor;
+    inputButton.autoresizingMask = UIViewAutoresizingFlexibleLeftMargin |
+                                   UIViewAutoresizingFlexibleRightMargin |
+                                   UIViewAutoresizingFlexibleTopMargin |
+                                   UIViewAutoresizingFlexibleBottomMargin;
+
+    UITapGestureRecognizer *tap = [[UITapGestureRecognizer alloc] initWithTarget:self
+                                                                          action:@selector(toggleMenu:)];
+    UIPanGestureRecognizer *pan = [[UIPanGestureRecognizer alloc] initWithTarget:self
+                                                                          action:@selector(moveLauncher:)];
+    [inputButton addGestureRecognizer:tap];
+    [inputButton addGestureRecognizer:pan];
+
+    [self.rootView addSubview:inputButton];
+    self.launcherInputButton = inputButton;
+
+    UIButton *visualButton = [UIButton buttonWithType:UIButtonTypeCustom];
+    visualButton.frame = frame;
+    visualButton.center = initialCenter;
+    visualButton.userInteractionEnabled = NO;
+    visualButton.backgroundColor = [UIColor colorWithWhite:0.08f alpha:0.78f];
+    visualButton.tintColor = UIColor.whiteColor;
+    visualButton.layer.cornerRadius = kLauncherSize * 0.5f;
+    visualButton.clipsToBounds = YES;
+
+    UIImage *icon = [UIImage systemImageNamed:@"circle.grid.2x2.fill"];
+    [visualButton setImage:icon forState:UIControlStateNormal];
+
+    [self.overlayHostView addSubview:visualButton];
+    self.launcherVisualButton = visualButton;
+}
+
+- (void)toggleMenu:(UITapGestureRecognizer *)gesture {
+    if (gesture.state != UIGestureRecognizerStateEnded) return;
+
+    BOOL visible = ![ImGuiDrawView isMenuShowing];
+    [ImGuiDrawView setMenuVisible:visible];
+    self.touchView.userInteractionEnabled = visible;
+
+    if (!visible) {
+        // Ensure ImGui does not retain a pressed pointer when the menu closes mid-touch.
+        UIEvent *event = gesture.view.window ? nil : nil;
+        (void)event;
     }
 }
 
-- (void)buttonDragged:(UIButton *)button withEvent:(UIEvent *)event {
-    UITouch *touch = [[event touchesForView:button] anyObject];
+- (void)moveLauncher:(UIPanGestureRecognizer *)gesture {
+    CGPoint translation = [gesture translationInView:self.rootView];
+    CGPoint center = self.launcherInputButton.center;
+    center.x += translation.x;
+    center.y += translation.y;
 
-    CGPoint previousLocation = [touch previousLocationInView:button];
-    CGPoint location = [touch locationInView:button];
-    CGFloat delta_x = location.x - previousLocation.x;
-    CGFloat delta_y = location.y - previousLocation.y;
-
-    UIView *mainView = [self hostView];
-    CGPoint unclampedOrigin = CGPointMake(button.frame.origin.x + delta_x, button.frame.origin.y + delta_y);
-    CGPoint clampedOrigin = [self clampedButtonOriginForOrigin:unclampedOrigin inView:mainView];
-    [self applyFloatingButtonFrame:CGRectMake(clampedOrigin.x, clampedOrigin.y, kFloatingButtonSize, kFloatingButtonSize) animated:NO];
+    [self setLauncherCenter:center];
+    [gesture setTranslation:CGPointZero inView:self.rootView];
 }
 
-- (void)buttonTouchDown:(UIButton *)button {
-    [self updateFloatingButtonVisualScale:kFloatingButtonPressedScale animated:YES];
+- (void)setLauncherCenter:(CGPoint)center {
+    CGRect bounds = self.rootView.bounds;
+    CGFloat radius = kLauncherSize * 0.5f;
+
+    center.x = MAX(radius, MIN(center.x, CGRectGetWidth(bounds) - radius));
+    center.y = MAX(radius, MIN(center.y, CGRectGetHeight(bounds) - radius));
+
+    self.launcherInputButton.center = center;
+    self.launcherVisualButton.center = center;
 }
 
-- (void)buttonTouchReleased:(UIButton *)button {
-    [self updateFloatingButtonVisualScale:[ImGuiDrawView isMenuShowing] ? kFloatingButtonPressedScale : 1.0f animated:YES];
-    [self snapFloatingButtonToEdgeAnimated:YES];
++ (void)applyStreamerMode:(BOOL)enabled {
+    dispatch_async(dispatch_get_main_queue(), ^{
+        MenuLoad *manager = [MenuLoad sharedManager];
+        manager.captureTextField.secureTextEntry = enabled;
+    });
 }
 
 @end

--- a/MenuLoad/MenuLoad.mm
+++ b/MenuLoad/MenuLoad.mm
@@ -221,12 +221,6 @@ UIWindow *ActiveWindow() {
     BOOL visible = ![ImGuiDrawView isMenuShowing];
     [ImGuiDrawView setMenuVisible:visible];
     self.touchView.userInteractionEnabled = visible;
-
-    if (!visible) {
-        // Ensure ImGui does not retain a pressed pointer when the menu closes mid-touch.
-        UIEvent *event = gesture.view.window ? nil : nil;
-        (void)event;
-    }
 }
 
 - (void)moveLauncher:(UIPanGestureRecognizer *)gesture {

--- a/MenuLoad/TweakManager.h
+++ b/MenuLoad/TweakManager.h
@@ -1,0 +1,13 @@
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+// Single bootstrap/coordinator for the tweak runtime.
+@interface TweakManager : NSObject
+
++ (instancetype)sharedManager;
+- (void)start;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/MenuLoad/TweakManager.mm
+++ b/MenuLoad/TweakManager.mm
@@ -1,0 +1,34 @@
+#import "TweakManager.h"
+#import "MenuLoad.h"
+#import "../Source/BasicHacks.h"
+
+@implementation TweakManager {
+    BOOL _started;
+}
+
++ (instancetype)sharedManager {
+    static TweakManager *manager = nil;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        manager = [[TweakManager alloc] init];
+    });
+    return manager;
+}
+
++ (void)load {
+    // Preserve the original delayed startup while keeping bootstrap logic in one place.
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 3 * NSEC_PER_SEC),
+                   dispatch_get_main_queue(), ^{
+        [[TweakManager sharedManager] start];
+    });
+}
+
+- (void)start {
+    if (_started) return;
+    _started = YES;
+
+    BasicCheats.Initialize();
+    [[MenuLoad sharedManager] start];
+}
+
+@end

--- a/MenuLoad/UserMenu.h
+++ b/MenuLoad/UserMenu.h
@@ -1,29 +1,28 @@
-/*
-IOS Theos Template Komaru
-Jailed (NoJB) Mod Menu Template for iOS Games
-By aq9
-https://github.com/VenerableCode/iOS-Theos-ModMenuTemp-NoJB
-*/
-
-
-
 #pragma once
 
 class UserMenu {
 public:
     UserMenu(const UserMenu&) = delete;
+    UserMenu& operator=(const UserMenu&) = delete;
 
     static UserMenu& GetInstance() {
-        static UserMenu Instance;
-        return Instance;
+        static UserMenu instance;
+        return instance;
     }
 
+    // Main entry point used by the renderer.
+    void Draw(bool menuVisible);
+
+    // Compatibility helpers retained for existing template code.
     void DrawMenu();
     void RenderingMenu();
     void Initialize();
 
 private:
-    UserMenu() { }
+    UserMenu() = default;
+
+    void DrawMainMenu();
+    void DrawOverlay();
 };
 
 static UserMenu& Menu = UserMenu::GetInstance();

--- a/MenuLoad/UserMenu.mm
+++ b/MenuLoad/UserMenu.mm
@@ -1,24 +1,20 @@
-/*
-IOS Theos Template Komaru
-Jailed (NoJB) Mod Menu Template for iOS Games
-By aq9
-https://github.com/VenerableCode/iOS-Theos-ModMenuTemp-NoJB
-*/
-
-
 #include "UserMenu.h"
-#include "Includes.h"
+#include "AppState.h"
+
+#import "MenuLoad.h"
+
+#include "../ImGui/imgui.h"
+
+#include <cmath>
+#include <cstdio>
 
 namespace {
+constexpr float kMenuWindowWidth = 275.0f;
+constexpr float kMenuWindowHeight = 250.0f;
 constexpr ImU32 kHealthBarBackgroundColor = IM_COL32(18, 24, 30, 180);
 constexpr float kMaxColorValue = 255.0f;
 constexpr int kHealthBarFillBlue = 90;
 constexpr int kHealthBarFillAlpha = 230;
-constexpr float kMenuWindowWidth = 275.0f;
-constexpr float kMenuWindowHeight = 250.0f;
-constexpr int kTrackedLabelBufferLength = 40;
-constexpr int kInfoLabelBufferLength = 96;
-constexpr int kHealthLabelBufferLength = 48;
 constexpr float kOverlayHeaderX = 18.0f;
 constexpr float kOverlayHeaderY = 18.0f;
 constexpr float kOverlaySubheaderY = 38.0f;
@@ -31,104 +27,148 @@ constexpr int kMarkerSegments = 24;
 constexpr float kMarkerOutlineThickness = 1.2f;
 
 struct MockEspEntity {
-    const char* Name;
-    float PhaseOffset;
-    float OrbitScaleX;
-    float OrbitScaleY;
-    float HeightScale;
-    float WidthScale;
-    ImU32 Color;
-    float HealthOffset;
+    const char *name;
+    float phaseOffset;
+    float orbitScaleX;
+    float orbitScaleY;
+    float heightScale;
+    float widthScale;
+    ImU32 color;
+    float healthOffset;
 };
 
 struct MockEspState {
-    ImVec2 Head;
-    ImVec2 BoxMin;
-    ImVec2 BoxMax;
-    float BoxHeight;
-    float HealthRatio;
-    float DistanceMeters;
-    float MarkerOuterRadius;
+    ImVec2 head;
+    ImVec2 boxMin;
+    ImVec2 boxMax;
+    float boxHeight;
+    float healthRatio;
+    float distanceMeters;
+    float markerOuterRadius;
 };
 
-void DrawHealthBar(ImDrawList* drawList, const ImVec2& topLeft, float height, float healthRatio) {
-    const float barWidth = 6.0f;
-    const float barPadding = 8.0f;
-    ImVec2 barMin = ImVec2(topLeft.x - barPadding - barWidth, topLeft.y);
-    ImVec2 barMax = ImVec2(barMin.x + barWidth, topLeft.y + height);
+void DrawHealthBar(ImDrawList *drawList, const ImVec2& topLeft, float height, float healthRatio) {
+    constexpr float barWidth = 6.0f;
+    constexpr float barPadding = 8.0f;
+
+    ImVec2 barMin(topLeft.x - barPadding - barWidth, topLeft.y);
+    ImVec2 barMax(barMin.x + barWidth, topLeft.y + height);
     drawList->AddRectFilled(barMin, barMax, kHealthBarBackgroundColor, 3.0f);
 
-    float clampedHealth = fminf(fmaxf(healthRatio, 0.0f), 1.0f);
-    float filledTop = barMax.y - (height * clampedHealth);
-    ImVec2 fillMin = ImVec2(barMin.x + 1.0f, filledTop);
-    ImVec2 fillMax = ImVec2(barMax.x - 1.0f, barMax.y - 1.0f);
-    ImU32 fillColor = IM_COL32((int)((1.0f - clampedHealth) * kMaxColorValue), (int)(clampedHealth * kMaxColorValue), kHealthBarFillBlue, kHealthBarFillAlpha);
+    const float clampedHealth = fminf(fmaxf(healthRatio, 0.0f), 1.0f);
+    const float filledTop = barMax.y - (height * clampedHealth);
+    const ImVec2 fillMin(barMin.x + 1.0f, filledTop);
+    const ImVec2 fillMax(barMax.x - 1.0f, barMax.y - 1.0f);
+    const ImU32 fillColor = IM_COL32(
+        (int)((1.0f - clampedHealth) * kMaxColorValue),
+        (int)(clampedHealth * kMaxColorValue),
+        kHealthBarFillBlue,
+        kHealthBarFillAlpha
+    );
+
     drawList->AddRectFilled(fillMin, fillMax, fillColor, 2.0f);
     drawList->AddRect(barMin, barMax, IM_COL32(255, 255, 255, 80), 3.0f, 0, 1.0f);
 }
 
-void DrawOverlayStatus(ImDrawList* drawList, const ImVec2& displaySize, int trackedCount) {
-    char trackedLabel[kTrackedLabelBufferLength];
+void DrawOverlayStatus(ImDrawList *drawList, const ImVec2& displaySize, int trackedCount) {
+    char trackedLabel[40];
     snprintf(trackedLabel, sizeof(trackedLabel), "%d MOCK TARGETS TRACKED", trackedCount);
-    drawList->AddText(ImVec2(kOverlayHeaderX, kOverlayHeaderY), IM_COL32(255, 255, 255, 235), "ESP OVERLAY");
-    drawList->AddText(ImVec2(kOverlayHeaderX, kOverlaySubheaderY), IM_COL32(120, 255, 180, 225), trackedLabel);
-    drawList->AddText(ImVec2(displaySize.x - kOverlayStatusRightInset, kOverlayHeaderY), IM_COL32(255, 210, 120, 225), "DEMO SIGNAL: STABLE");
+
+    drawList->AddText(ImVec2(kOverlayHeaderX, kOverlayHeaderY),
+                      IM_COL32(255, 255, 255, 235), "ESP OVERLAY");
+    drawList->AddText(ImVec2(kOverlayHeaderX, kOverlaySubheaderY),
+                      IM_COL32(120, 255, 180, 225), trackedLabel);
+    drawList->AddText(ImVec2(displaySize.x - kOverlayStatusRightInset, kOverlayHeaderY),
+                      IM_COL32(255, 210, 120, 225), "DEMO SIGNAL: STABLE");
 }
 
-void DrawEspSnapline(ImDrawList* drawList, const ImVec2& origin, const MockEspState& state, ImU32 color) {
-    drawList->AddLine(origin, ImVec2(state.Head.x, state.BoxMax.y), color, kSnaplineThickness);
+void DrawEspEntity(ImDrawList *drawList,
+                   const ImVec2& snaplineOrigin,
+                   const MockEspEntity& entity,
+                   const MockEspState& state) {
+    if (KTempVars.ShowEspSnaplines) {
+        drawList->AddLine(snaplineOrigin,
+                          ImVec2(state.head.x, state.boxMax.y),
+                          entity.color,
+                          kSnaplineThickness);
+    }
+
+    if (KTempVars.ShowEspMarkers) {
+        drawList->AddCircleFilled(state.head, kMarkerInnerRadius, entity.color);
+        drawList->AddCircle(state.head,
+                            state.markerOuterRadius,
+                            entity.color,
+                            kMarkerSegments,
+                            kMarkerOutlineThickness);
+    }
+
+    if (KTempVars.ShowEspBoxes) {
+        drawList->AddRect(state.boxMin, state.boxMax, entity.color, 5.0f, 0, 2.0f);
+        drawList->AddRect(ImVec2(state.boxMin.x - 2.0f, state.boxMin.y - 2.0f),
+                          ImVec2(state.boxMax.x + 2.0f, state.boxMax.y + 2.0f),
+                          IM_COL32(255, 255, 255, 45),
+                          6.0f,
+                          0,
+                          1.0f);
+    }
+
+    if (KTempVars.ShowEspHealthBars) {
+        DrawHealthBar(drawList, state.boxMin, state.boxHeight, state.healthRatio);
+    }
+
+    if (KTempVars.ShowEspLabels) {
+        char infoLabel[96];
+        snprintf(infoLabel, sizeof(infoLabel), "%s  %.0fm", entity.name, state.distanceMeters);
+        drawList->AddText(ImVec2(state.boxMin.x, state.boxMin.y - 18.0f),
+                          IM_COL32(255, 255, 255, 235), infoLabel);
+
+        char healthLabel[48];
+        snprintf(healthLabel, sizeof(healthLabel), "HP %d%%", (int)(state.healthRatio * 100.0f));
+        drawList->AddText(ImVec2(state.boxMin.x, state.boxMax.y + 8.0f),
+                          IM_COL32(190, 255, 200, 225), healthLabel);
+    }
+}
+} // namespace
+
+void UserMenu::Draw(bool menuVisible) {
+    if (menuVisible) {
+        DrawMainMenu();
+    }
+
+    DrawOverlay();
 }
 
-void DrawEspMarker(ImDrawList* drawList, const MockEspState& state, ImU32 color) {
-    drawList->AddCircleFilled(state.Head, kMarkerInnerRadius, color);
-    drawList->AddCircle(state.Head, state.MarkerOuterRadius, color, kMarkerSegments, kMarkerOutlineThickness);
-}
+void UserMenu::DrawMainMenu() {
+    const ImVec2 displaySize = ImGui::GetIO().DisplaySize;
+    const ImVec2 windowSize(kMenuWindowWidth, kMenuWindowHeight);
+    const ImVec2 windowPosition(
+        (displaySize.x - windowSize.x) * 0.5f,
+        (displaySize.y - windowSize.y) * 0.5f
+    );
 
-void DrawEspBox(ImDrawList* drawList, const MockEspState& state, ImU32 color) {
-    drawList->AddRect(state.BoxMin, state.BoxMax, color, 5.0f, 0, 2.0f);
-    drawList->AddRect(ImVec2(state.BoxMin.x - 2.0f, state.BoxMin.y - 2.0f), ImVec2(state.BoxMax.x + 2.0f, state.BoxMax.y + 2.0f), IM_COL32(255, 255, 255, 45), 6.0f, 0, 1.0f);
-}
+    ImGui::SetNextWindowSize(windowSize, ImGuiCond_Once);
+    ImGui::SetNextWindowPos(windowPosition, ImGuiCond_Once);
 
-void DrawEspLabels(ImDrawList* drawList, const MockEspEntity& entity, const MockEspState& state) {
-    char infoLabel[kInfoLabelBufferLength];
-    snprintf(infoLabel, sizeof(infoLabel), "%s  %.0fm", entity.Name, state.DistanceMeters);
-    drawList->AddText(ImVec2(state.BoxMin.x, state.BoxMin.y - 18.0f), IM_COL32(255, 255, 255, 235), infoLabel);
+    ImGuiWindowFlags flags = ImGuiWindowFlags_NoCollapse;
+    if (!KTempVars.MoveMenu) {
+        flags |= ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoMove;
+    }
 
-    char healthLabel[kHealthLabelBufferLength];
-    snprintf(healthLabel, sizeof(healthLabel), "HP %d%%", (int)(state.HealthRatio * 100.0f));
-    drawList->AddText(ImVec2(state.BoxMin.x, state.BoxMax.y + 8.0f), IM_COL32(190, 255, 200, 225), healthLabel);
-}
-}
-
-void UserMenu::DrawMenu()
-{
-
-
-    //ImVec2 menuPos = ImGui::GetWindowPos();
-	//ImVec2 windowsize = ImGui::GetWindowSize();
-
-    ImVec2 WindowSize = ImVec2(kMenuWindowWidth, kMenuWindowHeight);
-    ImGui::SetNextWindowSize(WindowSize, ImGuiCond_Once);
-
-    ImVec2 WindowPosition = ImVec2((SCREEN_WIDTH - WindowSize.x) / 2, (SCREEN_HEIGHT - WindowSize.y) / 2);
-    ImGui::SetNextWindowPos(WindowPosition, ImGuiCond_Once);
-
-    ImGuiWindowFlags WindowFlags = KTempVars.MoveMenu ? ImGuiWindowFlags_NoCollapse : ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoMove;
-
-    if (ImGui::Begin("KomaruTemp", NULL, WindowFlags))
-    {
-        ImGuiWindow* CurrentWindow = ImGui::GetCurrentWindow();
-        KTempVars.MenuSize   = CurrentWindow->Size;
-        KTempVars.MenuOrigin = CurrentWindow->Pos;
+    if (ImGui::Begin("KomaruTemp", nullptr, flags)) {
+        KTempVars.MenuSize = ImGui::GetWindowSize();
+        KTempVars.MenuOrigin = ImGui::GetWindowPos();
 
         ImGui::SliderFloat("FOV Changer", &KTempVars.CameraFOV, 60.0f, 160.0f);
 
-        //misc menu options
         ImGui::Checkbox("Move Menu", &KTempVars.MoveMenu);
         ImGui::SameLine();
-        ImGui::Checkbox("Streamer Mode", &KTempVars.StreamerMode);
+
+        if (ImGui::Checkbox("Streamer Mode", &KTempVars.StreamerMode)) {
+            [MenuLoad applyStreamerMode:KTempVars.StreamerMode];
+        }
+
         ImGui::Separator();
-        ImGui::Text("ESP Overlay");
+        ImGui::TextUnformatted("ESP Overlay");
         ImGui::Checkbox("Enable Overlay", &KTempVars.ShowEspOverlay);
         ImGui::Checkbox("Snaplines", &KTempVars.ShowEspSnaplines);
         ImGui::SameLine();
@@ -137,34 +177,18 @@ void UserMenu::DrawMenu()
         ImGui::SameLine();
         ImGui::Checkbox("Labels", &KTempVars.ShowEspLabels);
         ImGui::Checkbox("Health Bars", &KTempVars.ShowEspHealthBars);
-
     }
+
     ImGui::End();
 }
 
+void UserMenu::DrawOverlay() {
+    if (!KTempVars.ShowEspOverlay) return;
 
-void UserMenu::RenderingMenu()
-{
-    ImGui::SetNextWindowPos(ImVec2(0.0f, 0.0f), ImGuiCond_Always);
-    ImGui::SetNextWindowSize(ImVec2(SCREEN_WIDTH, SCREEN_HEIGHT), ImGuiCond_Always);
-    ImGui::Begin("RenderMenu", nullptr,
-        ImGuiWindowFlags_NoTitleBar |
-        ImGuiWindowFlags_NoResize |
-        ImGuiWindowFlags_NoMove |
-        ImGuiWindowFlags_NoBackground |
-        ImGuiWindowFlags_NoScrollbar |
-        ImGuiWindowFlags_NoSavedSettings |
-        ImGuiWindowFlags_NoInputs);
-
-    ImDrawList* drawList = ImGui::GetBackgroundDrawList();
+    ImDrawList *drawList = ImGui::GetBackgroundDrawList();
     const ImVec2 displaySize = ImGui::GetIO().DisplaySize;
-    const ImVec2 snaplineOrigin = ImVec2(displaySize.x * 0.5f, displaySize.y * 0.15f);
+    const ImVec2 snaplineOrigin(displaySize.x * 0.5f, displaySize.y * 0.15f);
     const float time = (float)ImGui::GetTime();
-
-    if (!KTempVars.ShowEspOverlay) {
-        ImGui::End();
-        return;
-    }
 
     const MockEspEntity entities[] = {
         { "SCOUT-01", 0.0f, 0.27f, 0.18f, 122.0f, 0.42f, IM_COL32(90, 220, 255, 255), 0.15f },
@@ -175,48 +199,38 @@ void UserMenu::RenderingMenu()
     DrawOverlayStatus(drawList, displaySize, IM_ARRAYSIZE(entities));
 
     for (const MockEspEntity& entity : entities) {
-        float oscillation = time + entity.PhaseOffset;
-        float normalizedX = 0.5f + cosf(oscillation * 0.8f) * entity.OrbitScaleX;
-        float normalizedY = 0.52f + sinf(oscillation * 1.15f) * entity.OrbitScaleY;
-        ImVec2 head = ImVec2(displaySize.x * normalizedX, displaySize.y * normalizedY);
+        const float oscillation = time + entity.phaseOffset;
+        const float normalizedX = 0.5f + cosf(oscillation * 0.8f) * entity.orbitScaleX;
+        const float normalizedY = 0.52f + sinf(oscillation * 1.15f) * entity.orbitScaleY;
+        const ImVec2 head(displaySize.x * normalizedX, displaySize.y * normalizedY);
 
-        float boxHeight = entity.HeightScale + sinf(oscillation * 1.6f) * 8.0f;
-        float boxWidth = boxHeight * entity.WidthScale;
-        ImVec2 boxMin = ImVec2(head.x - (boxWidth * 0.5f), head.y - (boxHeight * 0.3f));
-        ImVec2 boxMax = ImVec2(head.x + (boxWidth * 0.5f), boxMin.y + boxHeight);
-        MockEspState state = {
+        const float boxHeight = entity.heightScale + sinf(oscillation * 1.6f) * 8.0f;
+        const float boxWidth = boxHeight * entity.widthScale;
+        const ImVec2 boxMin(head.x - boxWidth * 0.5f, head.y - boxHeight * 0.3f);
+        const ImVec2 boxMax(head.x + boxWidth * 0.5f, boxMin.y + boxHeight);
+
+        const MockEspState state = {
             head,
             boxMin,
             boxMax,
             boxHeight,
-            0.35f + fabsf(sinf(time * 0.75f + entity.HealthOffset)) * 0.6f,
-            18.0f + fabsf(cosf(time * 0.55f + entity.PhaseOffset)) * 42.0f,
+            0.35f + fabsf(sinf(time * 0.75f + entity.healthOffset)) * 0.6f,
+            18.0f + fabsf(cosf(time * 0.55f + entity.phaseOffset)) * 42.0f,
             kMarkerOuterBaseRadius + sinf(oscillation * 2.0f) * kMarkerPulseAmplitude,
         };
 
-        if (KTempVars.ShowEspSnaplines) {
-            DrawEspSnapline(drawList, snaplineOrigin, state, entity.Color);
-        }
-        if (KTempVars.ShowEspMarkers) {
-            DrawEspMarker(drawList, state, entity.Color);
-        }
-        if (KTempVars.ShowEspBoxes) {
-            DrawEspBox(drawList, state, entity.Color);
-        }
-        if (KTempVars.ShowEspHealthBars) {
-            DrawHealthBar(drawList, state.BoxMin, state.BoxHeight, state.HealthRatio);
-        }
-        if (KTempVars.ShowEspLabels) {
-            DrawEspLabels(drawList, entity, state);
-        }
+        DrawEspEntity(drawList, snaplineOrigin, entity, state);
     }
-
-    ImGui::End();
 }
 
+void UserMenu::DrawMenu() {
+    DrawMainMenu();
+}
 
-void UserMenu::Initialize()
-{
-    DrawMenu();
-    RenderingMenu();
+void UserMenu::RenderingMenu() {
+    DrawOverlay();
+}
+
+void UserMenu::Initialize() {
+    Draw(true);
 }


### PR DESCRIPTION
## Summary

Refactors the template around clearer runtime boundaries without changing the existing sample feature/state API unnecessarily.

### Architecture
- adds `TweakManager` as the single startup coordinator
- adds `ImGuiController` for ImGui context/font/Metal frame lifecycle and touch translation
- adds `AppState` and retains `KTempVars` as a compatibility alias
- reduces `ImGuiDrawView` to Metal frame orchestration
- turns `MenuLoad` into the UIKit overlay/touch/launcher coordinator
- keeps `UserMenu` focused on ImGui controls and draw-list rendering

### Cleanup
- removes the large embedded Base64 launcher image in favour of an SF Symbol
- removes global UIKit objects from `Includes.h`
- removes the dependency on `imgui_internal.h` from menu code
- draws the non-interactive overlay directly through `GetBackgroundDrawList()` instead of an invisible full-screen ImGui window
- replaces `windows[0]` lookup with scene-aware active-window discovery
- updates `AGENTS.md` to document the new boundaries

### Compatibility
- existing `KTempVars.CameraFOV` feature code continues to work
- legacy `ImGuiDrawView::showChange`, `UserMenu::Initialize`, `DrawMenu`, and `RenderingMenu` entry points are retained as compatibility helpers
- existing Makefile wildcard rules already include the new `.mm` files

### Verification
Static architecture/dependency review completed. A Theos/iOS runtime build is still required to validate the secure-text-field capture behaviour and Metal presentation on-device.